### PR TITLE
[draft] feat: add gpg signing

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,9 @@ plugs:
     read:
       - $HOME/.gitconfig
       - $HOME/.config/git
+    #write:
+      # gpg in core24 fails if it cannot create a lock file
+      #- $HOME/.gnupg
   system-gitconfig:
     interface: system-files
     read:
@@ -35,12 +38,35 @@ layout:
     bind: $SNAP/usr/share/nano
   /etc/gitconfig:
     bind-file: $SNAP_DATA/etc/gitconfig
+  /etc/gnupg:
+    bind: $SNAP/etc/gnupg
+  /usr/bin/dirmngr:
+    bind-file: $SNAP/usr/bin/dirmngr
+  /usr/bin/gpg:
+    bind-file: $SNAP/usr/bin/gpg
+  /usr/bin/gpg-agent:
+    bind-file: $SNAP/usr/bin/gpg-agent
+  /usr/bin/gpg-connect-agent:
+    bind-file: $SNAP/usr/bin/gpg-connect-agent
+  /usr/bin/gpgconf:
+    bind-file: $SNAP/usr/bin/gpgconf
+  /usr/bin/gpgsm:
+    bind-file: $SNAP/usr/bin/gpgsm
+  /usr/bin/gpgv:
+    bind-file: $SNAP/usr/bin/gpgv
+  /usr/bin/pinentry:
+    bind-file: $SNAP/usr/bin/pinentry-gnome3
+  /usr/lib/gnupg:
+    bind: $SNAP/usr/lib/gnupg
+  /usr/share/gnupg:
+    bind: $SNAP/usr/share/gnupg
 
 apps:
   gitu:
     command: wrapper.sh
     environment:
       GIT_CONFIG_GLOBAL: "$SNAP_REAL_HOME/.gitconfig"
+      GNUPGHOME: "$SNAP_REAL_HOME/.gnupg"
     plugs:
       - home
       - network
@@ -55,6 +81,7 @@ parts:
     source: https://github.com/altsem/gitu.git
     stage-packages:
       - git
+      - gnupg
       - vim-tiny
       - nano
     organize:


### PR DESCRIPTION
To support signed commits, the snap needs to access the gpg-agent socket.  Unfortunately, this is not trivial for a strictly confined snap.  

References:
- libreoffice: [Cannot sign a document, gpg keys are not listed](https://bugs.launchpad.net/ubuntu/+source/libreoffice/+bug/1772683)
- git-cola: [Signing files with GPG from within a snap](https://forum.snapcraft.io/t/signing-files-with-gpg-from-within-a-snap/5566)
- git-cola: [GPG signing not possible](https://github.com/brlin-tw/git-cola-snap/issues/7)
- forum post: [Gpg-agent socket binding](https://forum.snapcraft.io/t/gpg-agent-socket-binding/23245)
- rejected snapd PR: [interfaces/gpg-keys: Allow access to gpg-agent and creation of lockfiles](https://github.com/canonical/snapd/pull/7366)
- proof of concept: [gnupg2 snap](https://git.launchpad.net/~jdstrand/+git/test-gnupg2/tree/)
- archived snap with the closest implementation: [gopass-snap](https://github.com/ppd/gopass-snap/tree/master)